### PR TITLE
Added support for Bootstrap 4

### DIFF
--- a/dist/bootstrap-toolkit.js
+++ b/dist/bootstrap-toolkit.js
@@ -191,7 +191,7 @@
         use: function( frameworkName, breakpoints ) {
             self.framework = frameworkName.toLowerCase();
 
-            if( self.framework === 'bootstrap' || self.framework === 'foundation') {
+            if( self.framework === 'bootstrap' || self.framework === 'foundation' || self.framework == 'bootstrap4' ) {
                 self.breakpoints = internal.detectionDivs[ self.framework ];
             } else {
                 self.breakpoints = breakpoints;

--- a/dist/bootstrap-toolkit.js
+++ b/dist/bootstrap-toolkit.js
@@ -21,6 +21,14 @@
                 'md': $('<div class="device-md visible-md visible-md-block"></div>'),
                 'lg': $('<div class="device-lg visible-lg visible-lg-block"></div>')
             },
+            // Bootstrap 4
+            bootstrap4: {
+                'xs': $('<div class="hidden-sm-up"></div>'),
+                'sm': $('<div class="hidden-xs-down hidden-md-up"></div>'),
+                'md': $('<div class="hidden-sm-down hidden-lg-up"></div>'),
+                'lg': $('<div class="hidden-md-down hidden-xl-up"></div>'),
+                'xl': $('<div class="hidden-lg-down"></div>')
+            },
             // Foundation 5
             foundation: {
                 'small':  $('<div class="device-xs show-for-small-only"></div>'),


### PR DESCRIPTION
I added basic support for Bootstrap 4, which did away with the old `.hidden-*` and `.visible-*` classes. To do this, I added an additional property to the `detectionDivs` object. I did not know what you preferred to call it, so I just called it `bootstrap4`. I have tested this and used it in one of my projects, though it's not a _completely comprehensive_ test. I also didn't know how to minify my changes, so let me know if/how I should do that.