### PR TITLE
Support Bootstrap 4 + Proposed changed method fix

### DIFF
--- a/src/bootstrap-toolkit.js
+++ b/src/bootstrap-toolkit.js
@@ -10,9 +10,40 @@ var ResponsiveBootstrapToolkit = (function($){
     // Internal methods
     var internal = {
     	/**
-    	* Internal variable for the timer so it can be cancelled
+    	 * Internal variable for the timer so it can be cancelled
     	 */
-    	timer:null,
+    	timer: null,
+
+    	/**
+    	 * Variable to store the last known breakpoint
+    	 */
+    	lastBreakpoint: null,
+
+    	/**
+    	 * Can be a function that is called when the breakpoint changes
+    	 */
+    	onChange:null,
+
+    	/**
+    	 * Internal variable for timeout of 'onChange' function
+    	 */
+    	onChangeTimer: null,
+
+    	/**
+    	 * Window resized function
+    	 */
+    	windowResized: function(){
+    		clearTimeout(internal.onChangeTimer);
+    		internal.onChangeTimer = setInterval(function(){
+	    		if(internal.onChange){
+		    		var newBreakpoint = self.current();
+		            if(newBreakpoint!==internal.lastBreakpoint){
+                        internal.onChange(newBreakpoint, internal.lastBreakpoint);
+		            	internal.lastBreakpoint = newBreakpoint;
+		            }
+	            }
+    		},self.onChangeInterval);
+    	},
 
         /**
          * Breakpoint detection divs for each framework version
@@ -42,7 +73,7 @@ var ResponsiveBootstrapToolkit = (function($){
             }
         },
 
-         /**
+        /**
          * Append visibility divs after DOM laoded
          */
         applyDetectionDivs: function() {
@@ -170,6 +201,11 @@ var ResponsiveBootstrapToolkit = (function($){
         interval: 300,
 
         /**
+         * Determines default debouncing interval of 'onChange' method
+         */
+        onChangeInterval: 100,
+
+        /**
          *
          */
         framework: null,
@@ -228,6 +264,16 @@ var ResponsiveBootstrapToolkit = (function($){
                 }, ms || self.interval);
                 return this;
             })();
+        },
+
+        /*
+         * Adds an function to be called when current breakpoint changes
+         */
+        onChange: function(fn, ms) {
+            internal.onChange = fn;
+            if(ms){
+            	self.onChangeInterval = ms;
+            }
         }
 
     };
@@ -235,6 +281,7 @@ var ResponsiveBootstrapToolkit = (function($){
     // Create a placeholder
     $(document).ready(function(){
         $('<div class="responsive-bootstrap-toolkit"></div>').appendTo('body');
+        $(window).on("resize", internal.windowResized);
     });
 
     if( self.framework === null ) {

--- a/src/bootstrap-toolkit.js
+++ b/src/bootstrap-toolkit.js
@@ -13,14 +13,14 @@ var ResponsiveBootstrapToolkit = (function($){
          * Breakpoint detection divs for each framework version
          */
         detectionDivs: {
-            // Bootstrap 4
-            bootstrap4: {
+            // Bootstrap 4 - Kept in for future reference on BS4 Beta release
+            /*bootstrap4: {
                 'xs': $('<div class="device-xs d-block hidden-sm-up"></div>'),
                 'sm': $('<div class="device-sm d-block hidden-xs-down hidden-md-up"></div>'),
                 'md': $('<div class="device-md d-block hidden-sm-down hidden-lg-up"></div>'),
                 'lg': $('<div class="device-lg d-block hidden-md-down hidden-xl-up"></div>'),
                 'xl': $('<div class="device-xl d-block hidden-lg-down"></div>')
-            },
+            },*/
             // Bootstrap 3
             bootstrap: {
                 'xs': $('<div class="device-xs visible-xs visible-xs-block"></div>'),

--- a/src/bootstrap-toolkit.js
+++ b/src/bootstrap-toolkit.js
@@ -9,6 +9,10 @@ var ResponsiveBootstrapToolkit = (function($){
 
     // Internal methods
     var internal = {
+    	/**
+    	* Internal variable for the timer so it can be cancelled
+    	 */
+    	timer:null,
 
         /**
          * Breakpoint detection divs for each framework version
@@ -217,13 +221,13 @@ var ResponsiveBootstrapToolkit = (function($){
          * Waits specified number of miliseconds before executing a callback
          */
         changed: function(fn, ms) {
-            var timer;
-            return function(){
-                clearTimeout(timer);
-                timer = setTimeout(function(){
+            return (function(){
+                clearTimeout(internal.timer);
+                internal.timer = setTimeout(function(){
                     fn();
                 }, ms || self.interval);
-            };
+                return this;
+            })();
         }
 
     };

--- a/src/bootstrap-toolkit.js
+++ b/src/bootstrap-toolkit.js
@@ -109,7 +109,6 @@ var ResponsiveBootstrapToolkit = (function($){
             var expression = internal.splitExpression( str );
 
             // Get names of all breakpoints
-            console.log(self.breakpoints);
             var breakpointList = Object.keys(self.breakpoints);
 
             // Get index of sought breakpoint in the list
@@ -191,7 +190,7 @@ var ResponsiveBootstrapToolkit = (function($){
         use: function( frameworkName, breakpoints ) {
             self.framework = frameworkName.toLowerCase();
 
-            if( self.framework === 'bootstrap4' || self.framework === 'bootstrap' || self.framework === 'foundation') {
+            if( Object.keys(internal.detectionDivs).indexOf(self.framework) !== -1 ) {
                 self.breakpoints = internal.detectionDivs[ self.framework ];
             } else {
                 self.breakpoints = breakpoints;

--- a/src/bootstrap-toolkit.js
+++ b/src/bootstrap-toolkit.js
@@ -248,7 +248,7 @@ var ResponsiveBootstrapToolkit = (function($){
                 timer = setTimeout(function(){
                     var newBreakpoint = self.current();
                     if(newBreakpoint!==lastBreakpoint){
-                        fn(newBreakpoint, internal.lastBreakpoint);
+                        fn(newBreakpoint, lastBreakpoint);
                         lastBreakpoint = newBreakpoint;
                     }
                 }, ms || self.interval);

--- a/src/bootstrap-toolkit.js
+++ b/src/bootstrap-toolkit.js
@@ -21,6 +21,14 @@ var ResponsiveBootstrapToolkit = (function($){
                 'md': $('<div class="device-md visible-md visible-md-block"></div>'),
                 'lg': $('<div class="device-lg visible-lg visible-lg-block"></div>')
             },
+            // Bootstrap 4
+            bootstrap4: {
+                'xs': $('<div class="device-xs d-block"></div>'),
+                'sm': $('<div class="device-sm d-block hidden-xs-down hidden-md-up"></div>'),
+                'md': $('<div class="device-md d-block hidden-sm-down hidden-lg-up"></div>'),
+                'lg': $('<div class="device-lg d-block hidden-md-down hidden-xl-up"></div>'),
+                'xl': $('<div class="device-xl d-block hidden-lg-down"></div>')
+            },
             // Foundation 5
             foundation: {
                 'small':  $('<div class="device-xs show-for-small-only"></div>'),
@@ -183,7 +191,7 @@ var ResponsiveBootstrapToolkit = (function($){
         use: function( frameworkName, breakpoints ) {
             self.framework = frameworkName.toLowerCase();
 
-            if( self.framework === 'bootstrap' || self.framework === 'foundation') {
+            if( self.framework === 'bootstrap4' || self.framework === 'bootstrap' || self.framework === 'foundation') {
                 self.breakpoints = internal.detectionDivs[ self.framework ];
             } else {
                 self.breakpoints = breakpoints;

--- a/src/bootstrap-toolkit.js
+++ b/src/bootstrap-toolkit.js
@@ -32,7 +32,7 @@ var ResponsiveBootstrapToolkit = (function($){
     	/**
     	 * Window resized function
     	 */
-    	windowResized: function(){
+    	windowResized: function(ms){
     		clearTimeout(internal.onChangeTimer);
     		internal.onChangeTimer = setInterval(function(){
 	    		if(internal.onChange){
@@ -42,7 +42,7 @@ var ResponsiveBootstrapToolkit = (function($){
 		            	internal.lastBreakpoint = newBreakpoint;
 		            }
 	            }
-    		},self.onChangeInterval);
+    		}, ms || self.onChangeInterval );
     	},
 
         /**
@@ -274,6 +274,7 @@ var ResponsiveBootstrapToolkit = (function($){
             if(ms){
             	self.onChangeInterval = ms;
             }
+            internal.windowResized(1);
         }
 
     };

--- a/src/bootstrap-toolkit.js
+++ b/src/bootstrap-toolkit.js
@@ -109,6 +109,7 @@ var ResponsiveBootstrapToolkit = (function($){
             var expression = internal.splitExpression( str );
 
             // Get names of all breakpoints
+            console.log(self.breakpoints);
             var breakpointList = Object.keys(self.breakpoints);
 
             // Get index of sought breakpoint in the list

--- a/src/bootstrap-toolkit.js
+++ b/src/bootstrap-toolkit.js
@@ -162,12 +162,7 @@ var ResponsiveBootstrapToolkit = (function($){
         /**
          * Determines default debouncing interval of 'changed' method
          */
-        interval: 300,
-
-        /**
-         * Determines default debouncing interval of 'onChange' method
-         */
-        onChangeInterval: 100,
+        interval: 100,
 
         /**
          *


### PR DESCRIPTION
Sorry if there's a reason why you may not have a version supporting the current Bootstrap 4 Alpha versions - but if you wanted it, I thought this may be a useful addition.

Usage:
```js
viewport.use('bootstrap4');
```
Supports Bootstrap 4.0.0-alpha.6 (No longer using 'visible-*' See: https://v4-alpha.getbootstrap.com/migration/#responsive-utilities)

I've also noticed that the 'changed' function wasn't executing - so I've included another proposed fix for that and also to ensure the function is delayed until the user has not resized the screen for the given amount of time.

(It may also be nice to only trigger the user-defined function if the current breakpoint has actually changed, but that wouldn't be too hard to add if wanted).